### PR TITLE
Use Alpine netdata package for the container

### DIFF
--- a/netdata/Dockerfile
+++ b/netdata/Dockerfile
@@ -1,5 +1,23 @@
-FROM netdata/netdata
+FROM alpine:3.12.0
+ENV DOCKER_GRP netdata
+ENV DOCKER_USR netdata
+
+ENV NETDATA_PORT 19999
+
+RUN apk update && \
+	apk add netdata --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted && \
+	apk add curl \
+		jq \
+		shadow
 
 WORKDIR /etc/netdata
+
 COPY ./netdata.conf ./netdata.conf
 COPY ./balenad.conf ./python.d/dockerd.conf
+
+# Note: see `upstream-docker.run.sh` for where
+# /var/lib/netdata/cloud.d/cloud.conf is created; as this is a static
+# volume, we need to create it in the startup script.
+COPY ./startup.sh /usr/sbin/startup.sh
+
+ENTRYPOINT ["/usr/sbin/startup.sh"]

--- a/netdata/Dockerfile.armv7hf
+++ b/netdata/Dockerfile.armv7hf
@@ -1,6 +1,24 @@
-FROM netdata/netdata:latest-armhf
+FROM alpine:3.12.0
+ENV DOCKER_GRP netdata
+ENV DOCKER_USR netdata
+
+ENV NETDATA_PORT 19999
+
+RUN apk update && \
+	apk add netdata --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted && \
+	apk add curl \
+		jq \
+		shadow
 
 WORKDIR /etc/netdata
+
 COPY ./netdata.conf ./netdata.conf
-COPY ./rpi-charts.d.conf ./charts.d.conf
 COPY ./balenad.conf ./python.d/dockerd.conf
+COPY ./rpi-charts.d.conf ./charts.d.conf
+
+# Note: see `upstream-docker.run.sh` for where
+# /var/lib/netdata/cloud.d/cloud.conf is created; as this is a static
+# volume, we need to create it in the startup script.
+COPY ./startup.sh /usr/sbin/startup.sh
+
+ENTRYPOINT ["/usr/sbin/startup.sh"]

--- a/netdata/netdata.conf
+++ b/netdata/netdata.conf
@@ -2,5 +2,15 @@
     debug log = none
     error log = none
     access log = none
-#[web]
-#   default port = 80
+    run as user = netdata
+    # the default database size - 1 hour
+    history = 3600
+
+    # some defaults to run netdata with least priority
+    process scheduling policy = idle
+    OOM score = 1000
+
+[web]
+    web files owner = root
+    web files group = netdata
+    bind = *

--- a/netdata/startup.sh
+++ b/netdata/startup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Entry point script for netdata; rewrite of upstream startup script.
+
+# Opt out of usage gathering
+touch /etc/netdata/.opt-out-from-anonymous-statistics
+
+if [[ "${PGID}" ]]; then
+  echo "Creating docker group ${PGID}"
+  addgroup -g "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID} -- is it already there?"
+  echo "Adding netdata user to docker group ${PGID}"
+  usermod -a -G "${PGID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
+fi
+
+# This disables Agent-Cloud functionality
+# (https://learn.netdata.cloud/docs/agent/aclk#disable-the-aclk);
+# practically speaking, this removes the "Sign in" buttons for Netdata
+# Cloud.
+
+mkdir -p /var/lib/netdata/cloud.d
+cat > /var/lib/netdata/cloud.d/cloud.conf <<EOF
+[global]
+  enabled = no
+EOF
+
+# Set ownership correctly; this handles the case where the volumes
+# were attached to an earlier version of the container, with a
+# different uid for the netdata user.
+chown -R netdata:netdata /var/cache/netdata/
+chown -R netdata:netdata /var/lib/netdata
+
+chown -R netdata:root /var/lib/netdata/cloud.d
+chmod -R 770 /var/lib/netdata/cloud.d/
+
+exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" "$@"
+


### PR DESCRIPTION
By using the Alpine package in an Alpine container, instead of the Netdata container, we shrink the container size from ~ 300MB to 20MB.

One note: graphs for the various containers show up approximately 1 minute after the netdata container starts up. Presumably this is the time it takes netdata to ingest data on the various cgroups.

Screenshot:

![image](https://user-images.githubusercontent.com/1486793/86489896-8a945e00-bd1a-11ea-9608-906d329c9c9b.png)


Change-type: minor
Signed-off-by: Hugh Brown <hugh@balena.io>