### PR TITLE
Correct repo for armv7hf to community, not testing

### DIFF
--- a/netdata/Dockerfile.armv7hf
+++ b/netdata/Dockerfile.armv7hf
@@ -5,7 +5,7 @@ ENV DOCKER_USR netdata
 ENV NETDATA_PORT 19999
 
 RUN apk update && \
-	apk add netdata --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted && \
+	apk add netdata --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted && \
 	apk add curl \
 		jq \
 		shadow


### PR DESCRIPTION
This fixes the repo for netdata; the package is in `alpine/edge/community` now, not `testing`.  Local build:

```
$ balena push Pi3App --nocache
[Info]     Starting build for Pi3App, user gh_saintaardvark
[Info]     Dashboard link: https://dashboard.balena-staging.com/apps/108846/devices
[Info]     Building on arm02
[Info]     Pulling previous images for caching purposes...
[Success]  Successfully pulled cache images
[netdata]  Step 1/11 : FROM alpine:3.12.0
[netdata]   ---> 62ee0e9f8440
[netdata]  Step 2/11 : ENV DOCKER_GRP netdata
[netdata]   ---> Running in a30a01997715
[netdata]  Removing intermediate container a30a01997715
[netdata]   ---> da6837cebd0c
[netdata]  Step 3/11 : ENV DOCKER_USR netdata
[netdata]   ---> Running in 05af5e85099a
[netdata]  Removing intermediate container 05af5e85099a
[netdata]   ---> d51f1901f4c2
[netdata]  Step 4/11 : ENV NETDATA_PORT 19999
[netdata]   ---> Running in 7b209985cc78
[netdata]  Removing intermediate container 7b209985cc78
[netdata]   ---> 10988fc31902
[netdata]  Step 5/11 : RUN apk update && 	apk add netdata --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted && 	apk add curl 		jq 		shadow
[netdata]   ---> Running in 16aeb9e47f40
[netdata]  fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/aarch64/APKINDEX.tar.gz
[netdata]  fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/aarch64/APKINDEX.tar.gz
[netdata]  v3.12.0-376-gb3fc85f1ac [http://dl-cdn.alpinelinux.org/alpine/v3.12/main]
[netdata]  v3.12.0-380-g338f7f6f43 [http://dl-cdn.alpinelinux.org/alpine/v3.12/community]
[netdata]  OK: 12621 distinct packages available
[netdata]  fetch http://dl-3.alpinelinux.org/alpine/edge/community/aarch64/APKINDEX.tar.gz
[netdata]  fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/aarch64/APKINDEX.tar.gz
[netdata]  fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/aarch64/APKINDEX.tar.gz
[netdata]  (1/8) Installing ncurses-terminfo-base (6.2_p20200523-r0)
[netdata]  (2/8) Installing ncurses-libs (6.2_p20200523-r0)
[netdata]  (3/8) Installing readline (8.0.4-r0)
[netdata]  (4/8) Installing bash (5.0.17-r0)
[netdata]  Executing bash-5.0.17-r0.post-install
[netdata]  (5/8) Installing libcap (2.27-r0)
[netdata]  (6/8) Installing libuuid (2.35.2-r0)
[netdata]  (7/8) Installing libuv (1.38.1-r0)
[netdata]  (8/8) Installing netdata (1.25.0-r0)
[netdata]  Executing netdata-1.25.0-r0.pre-install
[netdata]  Executing busybox-1.31.1-r16.trigger
[netdata]  OK: 14 MiB in 22 packages
[netdata]  (1/8) Installing ca-certificates (20191127-r4)
[netdata]  (2/8) Installing nghttp2-libs (1.41.0-r0)
[netdata]  (3/8) Installing libcurl (7.69.1-r1)
[netdata]  (4/8) Installing curl (7.69.1-r1)
[netdata]  (5/8) Installing oniguruma (6.9.5-r1)
[netdata]  (6/8) Installing jq (1.6-r1)
[netdata]  (7/8) Installing linux-pam (1.3.1-r4)
[netdata]  (8/8) Installing shadow (4.8.1-r0)
[netdata]  Executing busybox-1.31.1-r16.trigger
[netdata]  Executing ca-certificates-20191127-r4.trigger
[netdata]  OK: 19 MiB in 30 packages
[netdata]  Removing intermediate container 16aeb9e47f40
[netdata]   ---> d553731bcf75
[netdata]  Step 6/11 : WORKDIR /etc/netdata
[netdata]   ---> Running in 2d5dde9f84d7
[netdata]  Removing intermediate container 2d5dde9f84d7
[netdata]   ---> dc986a159de2
[netdata]  Step 7/11 : COPY ./netdata.conf ./netdata.conf
[netdata]   ---> 06d43173c816
[netdata]  Step 8/11 : COPY ./balenad.conf ./python.d/dockerd.conf
[netdata]   ---> bfceb2f6c501
[netdata]  Step 9/11 : COPY ./rpi-charts.d.conf ./charts.d.conf
[netdata]   ---> 043abf68a1c4
[netdata]  Step 10/11 : COPY ./startup.sh /usr/sbin/startup.sh
[netdata]   ---> c2f3d1dab3c5
[netdata]  Step 11/11 : ENTRYPOINT ["/usr/sbin/startup.sh"]
[netdata]   ---> Running in 9d57c71721f8
[netdata]  Removing intermediate container 9d57c71721f8
[netdata]   ---> 9012dbbd4012
[netdata]  Successfully built 9012dbbd4012
[Info]     Uploading images
[Success]  Successfully uploaded images
[Info]     Built on arm02
[Success]  Release successfully created!
[Info]     Release: 3a5c6a0e15c8d9696684285029ac4bf0 (id: 127037)
[Info]     ┌─────────┬────────────┬────────────┐
[Info]     │ Service │ Image Size │ Build Time │
[Info]     ├─────────┼────────────┼────────────┤
[Info]     │ netdata │ 18.75 MB   │ 28 seconds │
[Info]     └─────────┴────────────┴────────────┘
[Info]     Build finished in 42 seconds
```

Connects-to: #23
Change-type: patch
Signed-off-by: Hugh Brown <hugh@balena.io>